### PR TITLE
Bring windows in current workspace using Shift+Return

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -220,11 +220,23 @@ function _showUI(mode, entryText, previousWidth) {
     return { whole: box, label: label, iconBox: new St.Bin(), shortcutBox: new St.Bin() };
   }
 
+  const bringWindowInWorkspaceHint = function () {
+    const box = new St.BoxLayout({style_class: 'switcher-box'});
+    const label = new St.Label({
+      style_class: 'switcher-label',
+      y_align: Clutter.ActorAlign.CENTER
+    });
+    label.clutter_text.set_text(_("Use Shift+Return to bring the window in the current workspace"));
+    box.insert_child_at_index(label, 0);
+    return { whole: box, label: label, iconBox: new St.Bin(), shortcutBox: new St.Bin() };
+  }
+
+  
   const makeBoxes = function(apps, mode) {
     mode.cleanIDs();
     return (apps.length > 0)
       ? apps.slice(0, mode.MAX_NUM_ITEMS).map(mode.makeBox)
-      : [ switchModeHint() ];
+      : [ switchModeHint(), bringWindowInWorkspaceHint() ];
   };
 
 
@@ -341,7 +353,8 @@ function _showUI(mode, entryText, previousWidth) {
         ((symbol === Clutter.j) && control)) {
       cleanUI();
       if (filteredApps.length > 0) {
-        if(shift) // If shift pressed, bring the window in our current workspace.
+        // If shift pressed and we are in switcher mode, bring the window in our current workspace.
+        if(mode.name() === "Switcher" && shift)
           filteredApps[cursor].change_workspace_by_index(global.screen.get_active_workspace_index(), true);
         mode.activate(filteredApps[cursor]);
       }

--- a/extension.js
+++ b/extension.js
@@ -341,6 +341,8 @@ function _showUI(mode, entryText, previousWidth) {
         ((symbol === Clutter.j) && control)) {
       cleanUI();
       if (filteredApps.length > 0) {
+        if(shift) // If shift pressed, bring the window in our current workspace.
+          filteredApps[cursor].change_workspace_by_index(global.screen.get_active_workspace_index(), true);
         mode.activate(filteredApps[cursor]);
       }
 


### PR DESCRIPTION
When we hit Shift-Return it brings the window in the current workspace instead of moving to the workspace of that windows. I have set it to Shift key because the Control key was already reserved for ctrl-j.

I miss this feature everyday... I work with a lot of open applications and often need, for instance, to bring my firefox to my current workspace. Does it make sense to you?

thanks,
Peter