### PR TITLE
Remove hardcoded white color fix introduced in #58 as it breaks dark themes

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -112,7 +112,8 @@ function _showUI(mode, entryText, previousWidth) {
   util.updateHighlight(boxes, entryText, cursor);
   timeit('after updateHighlight');
 
-  let entry = new St.Entry({ style_class: 'switcher-entry' });
+  /* use "search-entry" style from overview, combining it with our own */
+  let entry = new St.Entry({ style_class: 'search-entry switcher-entry' })
   entry.set_text(entryText);
   boxLayout.insert_child_at_index(entry, 0);
   boxes.forEach(box => boxLayout.insert_child_at_index(box.whole, -1));

--- a/stylesheet.css
+++ b/stylesheet.css
@@ -33,10 +33,8 @@
   background-color: #447dbc;
 }
 
-StEntry.switcher-entry {
+.switcher-entry {
   margin: .4em;
-  /* set explicitly the color (https://github.com/daniellandau/switcher/issues/58) */
-  color: #ffffff;
 }
 
 .switcher-shortcut {


### PR DESCRIPTION
The original fix in #58 breaks search on nearly every dark theme that has light font for the St.Entry boxes. Can we please revert it? I included a fix that uses the style from the Application search overview + the margin one specific to the extension.

The original fix never made sense because the Pop-dark Gnome shell themes PURPOSEFULLY sets brown text for it's St.Entry boxes. For example in Pop-Dark Application Overlay search has the exact same brown text against black background. See image attached with the PR.

![pop-dark gnome shell theme](https://user-images.githubusercontent.com/582074/42555781-4325b390-849e-11e8-9e54-a7be7968471c.png)

So really the issue is with Pop! dark theme not this extension. Meanwhile this wonderful extension is nearly unusable with most dark themes I tried :(