### PR TITLE
Update the width calculation for HiDPI scaling.

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -158,10 +158,11 @@ function _showUI(mode, entryText, previousWidth) {
   let shortcutWidth = boxes
     .map(box => (box.shortcutBox ? box.shortcutBox.width : 0))
     .reduce((a, b) => Math.max(a, b), 0);
+  let scaleFactor = St.ThemeContext.get_for_stage(global.stage).scale_factor;
   const maxWidth =
     Main.layoutManager.primaryMonitor.width *
     0.01 *
-    Convenience.getSettings().get_uint('max-width-percentage');
+    Convenience.getSettings().get_uint('max-width-percentage') * scaleFactor;
   if (width > maxWidth) width = maxWidth;
   if (width < maxWidth / 2) width = maxWidth / 2;
 


### PR DESCRIPTION
Adapted from how Gnome Shell itself does the scaling:
https://gitlab.gnome.org/search?utf8=✓&search=scaleFactor&group_id=&project_id=546&search_code=true&repository_ref=master

Tested on both HiDPI setup and regular one, looks the same. 