### PR TITLE
Always get current workspace index

### DIFF
--- a/util.js
+++ b/util.js
@@ -54,7 +54,7 @@ function getCurrentWorkspace() {
     return global.screen.get_active_workspace_index();
   } catch (_) {
     let workspaceManager = global.workspace_manager;
-    return workspaceManager.get_active_workspace();
+    return workspaceManager.get_active_workspace_index();
   }
 }
 


### PR DESCRIPTION
When falling back to using global.workspace_manager when global.screen isn't available, previously the workspace object would be returned, not the index.

This caused every window to be filtered out in the switcher when only-current-workspace was set, resulting in a switch to the launcher (which has results), preventing the switcher from being used.

Returning the workspace index, not object, fixes the issue.