### PR TITLE
add dbus based gnome control panels search

### DIFF
--- a/controlCenter.js
+++ b/controlCenter.js
@@ -1,0 +1,379 @@
+// -*- mode: js; js-indent-level: 4; indent-tabs-mode: nil -*-
+
+/* ------------------------------------------------------------------------- */
+"use strict";
+
+
+/* ------------------------------------------------------------------------- */
+const Gio = imports.gi.Gio;
+const GLib = imports.gi.GLib;
+
+
+/* ------------------------------------------------------------------------- */
+// use RemoteSearch dbus setup and keyfile constants
+const RemoteSearch = imports.ui.remoteSearch;
+
+
+/* ------------------------------------------------------------------------- */
+class GnomeControlCenterError extends Error { }
+
+
+/* ------------------------------------------------------------------------- */
+class SearchProviderConfiguration {
+
+  /* ....................................................................... */
+  constructor(
+    desktopId,
+    dbusName,
+    dbusPath,
+    providerApiVersion,
+    autoStart
+  ) {
+
+  this.desktopId = desktopId;
+  this.dbusName = dbusName;
+  this.dbusPath = dbusPath;
+  this.providerApiVersion = providerApiVersion;
+  this.autoStart = autoStart;
+  }
+}
+
+
+/* ------------------------------------------------------------------------- */
+var GnomeControlCenter = class GnomeControlCenter {
+
+  /* ....................................................................... */
+  // class constant for dbus time in milliseconds
+  /// (it's 2019 and ES does not support basic 'const', terrible)
+  get DBUS_PROXY_TIMEOUT() {
+    return 800;
+  }
+
+  /* ....................................................................... */
+  constructor() {
+
+    // "declare" instance variables ... so we know we what we use
+    this._providerConfiguration = null;
+    this._proxy = null;
+
+
+    // if successfull loaded search provider configuration then create proxy
+    try {
+      this._providerConfiguration = this._loadSearchProvider();
+      try {
+        this._proxy = this._createProxy();
+      }
+      catch (error) {
+        this._proxy = null;
+        log(error.toString());
+      }
+    }
+    catch (error) {
+      log(error.toString());
+    }
+  }
+
+  /* ....................................................................... */
+  get mainApplicationId() {
+    if (this._providerConfiguration !== null) {
+      return this._providerConfiguration.desktopId;
+    }
+    else {
+      return '';
+    }
+  }
+
+  /* ....................................................................... */
+  getPanelAppIDs() {
+
+    let panelIDs;
+    let panelMetas;
+    let panelAppIDs;
+
+    try {
+      // find all panel ids from the gnome control center dbus proxy using a
+      // syncronous call (will timeout in DBUS_PROXY_TIMEOUT)
+      panelIDs = this._makeDBusSyncCall(
+        this._proxy.GetInitialResultSetSync,
+        [
+          []
+        ],
+        'GetInitialResultSetSync'
+      )
+
+      // get the panel metas with information about panels
+      panelMetas = this._makeDBusSyncCall(
+        this._proxy.GetResultMetasSync,
+        [
+          panelIDs
+        ],
+        'GetResultMetasSync'
+      );
+    }
+    catch (error) {
+      log(error.toString());
+      return [];
+    }
+
+    // get app id names from panel meta information
+    panelAppIDs = [];
+    for (let i = 0; i < panelMetas.length; i++) {
+      // TODO: catch unpack error?
+      let appID = panelMetas[i]['id'].deep_unpack();
+      panelAppIDs.push(appID);
+    }
+
+    return panelAppIDs;
+  }
+
+  /* ....................................................................... */
+  _getSearchProviderConigurationFilePath() {
+
+    let filePath;
+    let dataDirs;
+    let errorMessage;
+
+    // get list of data dirs (i.e. /usr/share)
+    dataDirs = GLib.get_system_data_dirs();
+
+    // prepent user director ~/.local/share
+    dataDirs.unshift(GLib.get_user_data_dir());
+
+    // go over all the data dirs, look for gnome search config file assign it's
+    // path to filePath if found. preseed filePath to null so we know later
+    // if no path has been found
+    filePath = null;
+    for (let i = 0; i < dataDirs.length; i++) {
+      // build file path for gnome-control search provider
+      let possibleFilePath = GLib.build_filenamev([
+        dataDirs[i],
+        "gnome-shell",
+        "search-providers",
+        "gnome-control-center-search-provider.ini"
+      ]);
+      // check if the file exists and if so stop the search
+      if (GLib.file_test(possibleFilePath, GLib.FileTest.EXISTS) === true) {
+        filePath = possibleFilePath;
+        break;
+      }
+    }
+    if (filePath === null) {
+        errorMessage = ""
+          + "Could not find Gnome Control center search provider configuration"
+          +" file in any system or user data directories: "
+          + dataDirs.join(" ");
+      throw GnomeControlCenterError(errorMessage);
+    }
+
+    return filePath;
+  }
+
+  /* ....................................................................... */
+  _loadSearchProvider() {
+
+    let configFilePath;
+    let keyFile;
+    let group;
+    let errorMessage;
+
+    let desktopId;
+    let dbusName;
+    let dbusPath;
+    let providerApiVersion;
+    let autoStart;
+
+    try {
+      // get the configuration file path
+      configFilePath = this._getSearchProviderConigurationFilePath();
+
+      try {
+        // load key-value-file from passed in configFilePath
+        keyFile = new GLib.KeyFile();
+        keyFile.load_from_file(configFilePath, 0);
+
+        //  if keyfile has the search providers group section
+        group = "Shell Search Provider";
+        if (keyFile.has_group(group) === true) {
+          try {
+            // get the desktop id for the gnome search provider
+            desktopId = keyFile.get_string(group, "DesktopId");
+
+            // get search provider dbus bus name
+            dbusName = keyFile.get_string(group, "BusName");
+
+            // get search provider dbus object path
+            dbusPath = keyFile.get_string(group, "ObjectPath");
+
+            // get the version for the dbus interface used for search provider
+            providerApiVersion = keyFile.get_integer(group, "Version");
+
+            // get the autostart setting for the dbus services
+            // it's possible gnome control center does not have it specified
+            // though so we fallback to autoStart set to true
+            try {
+              autoStart = keyFile.get_boolean(group, "AutoStart");
+            }
+            catch(error) {
+              autoStart = true;
+            }
+          }
+          catch(error) {
+            errorMessage = ""
+              + "Failed to retrive desktop id and DBus configuration from "
+              + "search provider configuation file '%s': %s".format(
+                   configFilePath,
+                   error.toString()
+                )
+              throw(GnomeControlCenterError(errorMessage));
+          }
+        }
+        else {
+          errorMessage = ""
+            + "Loaded search provider configuration file '%s' does not "
+            + "contain '%s' configuration group".format(
+                configFilePath,
+                group
+              )
+          throw(GnomeControlCenterError(errorMessage));
+        }
+      }
+      catch(error) {
+        errorMessage = ""
+          + "Failed to load search provider configuration file '%s':"
+          + " %s".format(configFilePath)
+        throw GnomeControlCenterError(error);
+      }
+    }
+    catch (error) {
+      // re-throw error from _getSearchProviderConigurationFilePath
+      throw(error)
+    }
+
+    return new SearchProviderConfiguration(
+      desktopId,
+      dbusName,
+      dbusPath,
+      providerApiVersion,
+      autoStart
+    );
+  }
+
+  /* ...................................................................... */
+  _createProxy() {
+
+    // TODO: need a lot more arror handling
+
+    let proxy;
+    let proxyInfo;
+    let g_flags;
+    let errorMessage;
+
+    // TODO: these were copied from remoteSearch.js, still need to comment
+    //       as ti why we are doing this
+    g_flags = Gio.DBusProxyFlags.DO_NOT_LOAD_PROPERTIES;
+    if (this._providerConfiguration.autoStart === true) {
+      g_flags |= Gio.DBusProxyFlags.DO_NOT_AUTO_START_AT_CONSTRUCTION;
+    }
+    else {
+      g_flags |= Gio.DBusProxyFlags.DO_NOT_AUTO_START;
+    }
+
+    // load the dbus interface for the search provider, depending on version
+    // at Gnome 3.28 is  SearchProvider2ProxyInfo is used, but technically
+    // version 1 is still distributed, so many support it for now
+    if (this._providerConfiguration.providerApiVersion >= 2) {
+      proxyInfo = RemoteSearch.SearchProvider2ProxyInfo;
+    }
+    else {
+      proxyInfo = RemoteSearch.SearchProviderProxyInfo;
+    }
+
+    // create dbus proxy
+    try {
+      proxy = new Gio.DBusProxy({
+        g_bus_type: Gio.BusType.SESSION,
+        g_name: this._providerConfiguration.dbusName,
+        g_object_path: this._providerConfiguration.dbusPath,
+        g_interface_info: proxyInfo,
+        g_interface_name: proxyInfo.name,
+        g_flags: g_flags,
+        g_default_timeout: this.DBUS_PROXY_TIMEOUT
+      });
+
+      // initialize the proxy synchronously (basically blocking). this
+      // technically could be a problem if it blocks forever, though we expect
+      // the time out to handle it. Asynchronous initialization is conceptually
+      // more user friendly by being non-blocking however since switch other
+      // code is not currently async (desktop item scanning) this is necessary
+      // initialize dbus object with null for Cancelable, which means we can
+      // cancel it right now which should be fine since we do non-async calls
+      // to the dbus with timeout
+      proxy.init(null);
+    }
+    catch (error) {
+      errorMessage = ""
+        + "Failed to connect to Gnome Control Search Provider Dbus "
+        + "service: %s".format(error.toString());
+      throw(GnomeControlCenterError(errorMessage));
+    }
+
+    return proxy;
+  }
+
+  /* ....................................................................... */
+  _makeDBusSyncCall(func, args, func_name) {
+
+    let dbusReturn;
+    let errorMessage;
+
+    // check if proxy has been loaded before making the call.
+    // technically since we initialize proxy synchronously it should not be
+    // a problem in the first place. See _createProxy for more infromation
+    if (this._proxy !== null ) {
+
+      try {
+        // call passed in function with args and proxy as 'this' context
+        dbusReturn = func.apply(this._proxy, args);
+      }
+      catch (error) {
+        if (error instanceof Gio.IOErrorEnum) {
+          errorMessage = ""
+            + "Time out calling '%s' method of Gnome ".format(func_name)
+            + "Control Center DBus search provider, current "
+            +"timout is %d, ".format(this.DBUS_PROXY_TIMEOUT)
+            + "consider increasing it, error: %s".format(error.toString())
+          throw(GnomeControlCenterError(errorMessage));
+        }
+        else {
+          errorMessage = ""
+            + "Error calling '%s' method of Gnome ".format(func_name)
+            + "Control Center DBus search provider: "
+            + error.toString();
+          throw(GnomeControlCenterError(errorMessage));
+
+        }
+      }
+
+      // currently dbus methods we use return only 1 result, so check for
+      // if we got 1 result item only
+      if (dbusReturn.length == 1) {
+        return dbusReturn[0];
+      }
+      else {
+          errorMessage = ""
+            + "Failed to get result from '%s' method of ".format(func_name)
+            + "Gnome Control Center DBus search provider: "
+            + error.toString();
+          throw(GnomeControlCenterError(errorMessage));
+      }
+    }
+    else {
+      errorMessage = ""
+        + "Error calling '%s' method of Gnome ".format(func_name)
+        + "Control Center DBus search provider because DBus Proxy has not "
+        + "been loaded: " + this._proxy;
+      throw(GnomeControlCenterError(errorMessage));
+    }
+  }
+
+}

--- a/debug.sh
+++ b/debug.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+# error out on unset variables
+set -o nounset;
+# error out on the first error
+set -o errexit;
+# error out on pipe errors
+set -o pipefail;
+
+
+# get this scripts folder
+SCRIPT_FOLDER="$(cd $(dirname ${0}); pwd -P)";
+
+SESSION_TYPE="${1:-x11}";
+
+"${SCRIPT_FOLDER}/"session.sh \
+  "${SESSION_TYPE}" \
+  "${SCRIPT_FOLDER}/" \
+  "switcher@landau.fi" \
+;

--- a/modes/modeUtils.js
+++ b/modes/modeUtils.js
@@ -9,13 +9,33 @@ const ExtensionUtils = imports.misc.extensionUtils;
 const Me = ExtensionUtils.getCurrentExtension();
 const Convenience = Me.imports.convenience;
 const util = Me.imports.util;
+const controlCenter = Me.imports.controlCenter;
+const switcherApplication = Me.imports.switcherApplication;
 
 const keyActivation = Me.imports.keyActivation.KeyActivation;
 
 var ModeUtils = (function() {
+
+  let gnomeControlCenter;
+  let mainApplicationName;
+
+  // get gnome control center instance
+  gnomeControlCenter = new controlCenter.GnomeControlCenter();
+  if (gnomeControlCenter.mainApplicationId != '') {
+    try {
+      mainApplicationName = Shell.AppSystem.get_default()
+        .lookup_app(gnomeControlCenter.mainApplicationId).get_name();
+    }
+    catch (error) {
+      mainApplicationName = "";
+    }
+  }
+
   // From _loadApps() in GNOME Shell's appDisplay.js
-  let appInfos = () =>
-    Gio.AppInfo.get_all()
+  let appInfos = () => {
+
+    // get app ids for regular applications
+    let regularAppIDs = Gio.AppInfo.get_all()
       .filter(function(appInfo) {
         try {
           let id = appInfo.get_id(); // catch invalid file encodings
@@ -25,14 +45,37 @@ var ModeUtils = (function() {
         return appInfo.should_show();
       })
       .map(function(app) {
-        return app.get_id();
+        return new switcherApplication.RegularApplication(
+          app.get_id()
+        );
       });
+
+    // get gnome control center panel app ids
+    let gnomeControlCenterAppIDs = gnomeControlCenter.getPanelAppIDs().map(
+      function(appId) {
+        return new switcherApplication.GnomeControlApplication(
+          appId,
+          mainApplicationName
+        );
+      }
+    );
+    // combine Regular Apps ans and Gnome Control Apps ids
+    let allApps = regularAppIDs.concat(gnomeControlCenterAppIDs);
+
+    return allApps;
+  }
 
   let shellAppCache = { lastIndexed: null, apps: [] };
   let shellApps = (force) => {
     const get = () =>
-      appInfos().map(function(appID) {
-        return Shell.AppSystem.get_default().lookup_app(appID);
+      appInfos().map(function(switcherApp) {
+        let shellApp = Shell.AppSystem.get_default().lookup_app(
+          switcherApp.appId
+        );
+        // TODO: should this really be done during appInfos creation?
+        //       seems disjointed here
+        switcherApp.setShellApp(shellApp);
+        return switcherApp;
       });
     const update = () => {
       shellAppCache.lastIndexed = new Date();

--- a/session.sh
+++ b/session.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+
+# ........................................................................... #
+SIZE="900x1000"
+
+
+# ........................................................................... #
+# store current display port
+OLD_DISPLAY=$DISPLAY
+
+
+# ........................................................................... #
+# store positional parameters
+TYPE=${1:-$XDG_SESSION_TYPE};
+ROOT=$2;
+UUID=$3;
+
+
+# ........................................................................... #
+# find next X11 display free socket number
+d=0
+while [ -e /tmp/.X11-unix/X${d} ]; do
+    d=$((d + 1))
+done
+NEW_DISPLAY=:$d
+
+
+# ........................................................................... #
+XDG_RUNTIME_DIR=$(mktemp -d)
+CACHE=${XDG_CACHE_HOME:-$HOME/.cache}/${UUID}${SUFFIX}
+mkdir -p $CACHE
+export XDG_CONFIG_HOME=${CACHE}/config
+export XDG_DATA_HOME=${CACHE}/local
+mkdir -p $XDG_DATA_HOME/gnome-shell/extensions
+ln -fsn $ROOT $XDG_DATA_HOME/gnome-shell/extensions/${UUID}
+export XDG_CACHE_HOME=${CACHE}/cache
+
+# ........................................................................... #
+# export the DISPLAY variable so we can create a new dbus session
+DISPLAY=$NEW_DISPLAY
+# create new dbus socket and export it's address
+eval $(dbus-launch --exit-with-session --sh-syntax)
+echo $DBUS_SESSION_BUS_ADDRESS
+DISPLAY=$OLD_DISPLAY
+
+
+# ........................................................................... #
+# prepare for gnome-shell launch
+args=()
+case "$TYPE" in
+    wayland)
+        args=(--nested --wayland)
+        ;;
+    x11)
+        # launch Xephyr without access control and screen size of 1280x960
+        Xephyr -ac -screen "${SIZE}" $NEW_DISPLAY &
+        DISPLAY=$NEW_DISPLAY
+        args=--x11
+        ;;
+esac
+
+
+# ........................................................................... #
+# dconf reset -f /  # Reset settings
+dconf write /org/gnome/shell/enabled-extensions "['${UUID}']"
+
+
+# ........................................................................... #
+# preconfigure the environment for development
+# set static workspaces[org/gnome/mutter]
+#dconf write /org/gnome/shell/overrides/dynamic-workspaces false
+
+
+# ........................................................................... #
+# do not need FPS messages
+#export CLUTTER_SHOW_FPS=1
+export SHELL_DEBUG=all
+export MUTTER_DEBUG=1
+export MUTTER_DEBUG_NUM_DUMMY_MONITORS=1
+export MUTTER_DEBUG_DUMMY_MONITOR_SCALES=1
+export MUTTER_DEBUG_TILED_DUMMY_MONITORS=1
+
+
+# ........................................................................... #
+# hack to work around gnome resizing Xephyr screen
+# gnome-shell claims monitors.xml has an invalid mode, could not use it
+# even thought it was generated inside the Xephyr window
+# ----
+# enable job control so we can background gnome-shell to launch additional
+# commands
+set -m
+
+# ........................................................................... #
+# launch and background it
+gnome-shell ${args[*]} 2>&1 | sed 's/\x1b\[[0-9;]*m//g' &
+# wait for 5 seconds for gnome to start up
+sleep 5;
+
+# ........................................................................... #
+# resize the Xephyr screen post gnome start up
+xrandr --size "${SIZE}" &
+
+# ........................................................................... #
+# launch gnome-tweak
+gnome-tweaks &
+
+# ........................................................................... #
+# go back to waiting on the gnome-shell process
+wait %1

--- a/switcherApplication.js
+++ b/switcherApplication.js
@@ -1,0 +1,104 @@
+// -*- mode: js; js-indent-level: 4; indent-tabs-mode: nil -*-
+
+/* ------------------------------------------------------------------------- */
+"use strict";
+
+
+/* ------------------------------------------------------------------------- */
+class SwitcherApplication {
+
+  /* ....................................................................... */
+  constructor(appId, shellApp=null) {
+    this._appId = appId;
+    this._shellApp = shellApp;
+  }
+
+  /* ....................................................................... */
+  get appId() {
+    return this._appId;
+  }
+
+  /* ....................................................................... */
+  setShellApp(shellApp) {
+    this._shellApp = shellApp
+  }
+
+  /* ....................................................................... */
+  create_icon_texture(...args) {
+    return this._shellApp.create_icon_texture(...args);
+  }
+
+  /* ....................................................................... */
+  get_id() {
+    return this._shellApp.get_id();
+  }
+
+  /* ....................................................................... */
+  get_name() {
+    throw Error("'get_name' is not implemented");
+  }
+
+  /* ....................................................................... */
+  get_title() {
+    throw Error("'get_title' is not implemented");
+  }
+
+  /* ....................................................................... */
+  open_new_window(...args) {
+    return this._shellApp.open_new_window(...args);
+  }
+
+  /* ....................................................................... */
+  get_workspace() {
+    return this._shellApp.get_workspace()
+  }
+
+}
+
+
+/* ------------------------------------------------------------------------- */
+var RegularApplication = class RegularApplication extends SwitcherApplication {
+
+  /* ....................................................................... */
+  get_name() {
+    return this._shellApp.get_name();
+  }
+
+  /* ....................................................................... */
+  get_title() {
+    return this._shellApp.get_title();
+  }
+
+}
+
+
+/* ------------------------------------------------------------------------- */
+var GnomeControlApplication = class GnomeControlApplication
+  extends SwitcherApplication {
+
+  /* ....................................................................... */
+  constructor(appId, mainApplicationName="", shellApp=null) {
+    super(appId, shellApp)
+    this._mainApplicationName = mainApplicationName;
+
+    if (this._mainApplicationName !== "") {
+      this._nameSuffix = " (%s)".format(this._mainApplicationName);
+    }
+    else {
+      this._nameSuffix = "";
+    }
+  }
+
+  /* ....................................................................... */
+  get_name() {
+    return this._shellApp.get_name() + this._nameSuffix;
+  }
+
+  /* ....................................................................... */
+  get_title() {
+    // TODO; for X11 try to fish out WM_WINDOW_ROLE xprop to look up
+    //       the title
+    return this._shellApp.get_title();
+  }
+
+}


### PR DESCRIPTION
hi @daniellandau,

Great extension, thank you for it. This PR adds ability to search gnome panel via same dbus search provider the remoteSearch.js/search.js does in Gnome Shell.

Please let me know what you think of it. Some highlights.
- dbus search is synchronous with time out of 800 milliseconds (since app look and caching is too)
- Settings items have (Settings) suffix from gnome-control.desktop because otherwise items like "Keyboard" and "WiFi" just look more confusing. To do that I did some small work around classes. There is a pending TODO in modeUtils.js that I'd want your feedback on.