### PR TITLE
Gnome 45.0 compatibility

### DIFF
--- a/controlCenter.js
+++ b/controlCenter.js
@@ -4,15 +4,12 @@
 'use strict';
 
 /* ------------------------------------------------------------------------- */
-// const Gio = imports.gi.Gio;
 import Gio from 'gi://Gio';
-// const GLib = imports.gi.GLib;
 import GLib from 'gi://GLib';
 
 
 /* ------------------------------------------------------------------------- */
 // use RemoteSearch dbus setup and keyfile constants
-// const RemoteSearch = imports.ui.remoteSearch;
 import * as RemoteSearch from 'resource:///org/gnome/shell/ui/remoteSearch.js';
 
 /* ------------------------------------------------------------------------- */

--- a/controlCenter.js
+++ b/controlCenter.js
@@ -4,12 +4,16 @@
 'use strict';
 
 /* ------------------------------------------------------------------------- */
-const Gio = imports.gi.Gio;
-const GLib = imports.gi.GLib;
+// const Gio = imports.gi.Gio;
+import Gio from 'gi://Gio';
+// const GLib = imports.gi.GLib;
+import GLib from 'gi://GLib';
+
 
 /* ------------------------------------------------------------------------- */
 // use RemoteSearch dbus setup and keyfile constants
-const RemoteSearch = imports.ui.remoteSearch;
+// const RemoteSearch = imports.ui.remoteSearch;
+import * as RemoteSearch from 'resource:///org/gnome/shell/ui/remoteSearch.js';
 
 /* ------------------------------------------------------------------------- */
 class GnomeControlCenterError extends Error {}
@@ -29,7 +33,7 @@ class SearchProviderConfiguration {
 let panelAppIDs = [];
 
 /* ------------------------------------------------------------------------- */
-var GnomeControlCenter = class GnomeControlCenter {
+export var GnomeControlCenter = class GnomeControlCenter {
   /* ....................................................................... */
   // class constant for dbus time in milliseconds
   /// (it's 2019 and ES does not support basic 'const', terrible)

--- a/convenience.js
+++ b/convenience.js
@@ -1,19 +1,37 @@
 /*global imports, print */
-const ExtensionUtils = imports.misc.extensionUtils;
-const Gio = imports.gi.Gio;
-const Gettext = imports.gettext;
-const Config = imports.misc.config;
+//const ExtensionUtils = imports.misc.extensionUtils;
+//const Gio = imports.gi.Gio;
+import Gio from 'gi://Gio';
+// const Gettext = imports.gettext;
+// import * as Gettext from 'resource:///org/gnome/shell/extensions/extension.js';
+// const Config = imports.misc.config;
+// import * as Config from 'resource:///org/gnome/shell/misc/config.js';
+// import * as Config from 'resource:///org/gnome/Shell/Extensions/js/misc/config.js';
+
+// import {Extension} from 'resource:///org/gnome/shell/extensions/extension.js';
+// import {Extension} from 'resource:///org/gnome/Shell/Extensions/js/extensions/extension.js';
+
+async function importExtension() {
+  if (typeof global === 'undefined') {
+    // return (await import('resource:///org/gnome/Shell/Extensions/js/extensions/extension.js')).Extension;
+    return (await import('resource:///org/gnome/Shell/Extensions/js/extensions/prefs.js')).ExtensionPreferences;
+  }
+  return (await import('resource:///org/gnome/shell/extensions/extension.js')).Extension;
+}
+
+const Extension = await importExtension();
 
 let settings = null;
 
-function getSettings() {
+export function getSettings() {
   if (!settings) initSettings();
   return settings;
 }
 
 // copied from https://github.com/projecthamster/shell-extension/blob/f1f1d803395bc122db1b877985e1d2462c5215a9/convenience.js#L65
-function initSettings() {
-  const extension = ExtensionUtils.getCurrentExtension();
+export function initSettings() {
+  const extension = Extension.lookupByUUID('switcher@landau.fi');
+  console.log('extension: ' + extension);
   const schema = extension.metadata['settings-schema'];
   const GioSSS = Gio.SettingsSchemaSource;
   const schemaDir = extension.dir.get_child('schemas');
@@ -28,7 +46,7 @@ function initSettings() {
   settings = new Gio.Settings({ settings_schema: schemaObj });
 }
 
-function getJson(key) {
+export function getJson(key) {
   try {
     return JSON.parse(getSettings().get_string(key));
   } catch (e) {
@@ -37,29 +55,29 @@ function getJson(key) {
   }
 }
 
-function setJson(key, value) {
+export function setJson(key, value) {
   getSettings().set_string(key, JSON.stringify(value));
 }
 
-/**
- * initTranslations:
- * @domain: (optional): the gettext domain to use
- *
- * Initialize Gettext to load translations from extensionsdir/locale.
- * If @domain is not provided, it will be taken from metadata['gettext-domain']
- */
-function initTranslations(domain) {
-    let extension = ExtensionUtils.getCurrentExtension();
+// /**
+//  * initTranslations:
+//  * @domain: (optional): the gettext domain to use
+//  *
+//  * Initialize Gettext to load translations from extensionsdir/locale.
+//  * If @domain is not provided, it will be taken from metadata['gettext-domain']
+//  */
+// export function initTranslations(domain) {
+//     let extension = ExtensionUtils.getCurrentExtension();
 
-    domain = domain || extension.metadata['gettext-domain'];
+//     domain = domain || extension.metadata['gettext-domain'];
 
-    // check if this extension was built with "make zip-file", and thus
-    // has the locale files in a subfolder
-    // otherwise assume that extension has been installed in the
-    // same prefix as gnome-shell
-    let localeDir = extension.dir.get_child('locale');
-    if (localeDir.query_exists(null))
-        Gettext.bindtextdomain(domain, localeDir.get_path());
-    else
-        Gettext.bindtextdomain(domain, Config.LOCALEDIR);
-}
+//     // check if this extension was built with "make zip-file", and thus
+//     // has the locale files in a subfolder
+//     // otherwise assume that extension has been installed in the
+//     // same prefix as gnome-shell
+//     let localeDir = extension.dir.get_child('locale');
+//     if (localeDir.query_exists(null))
+//         Gettext.bindtextdomain(domain, localeDir.get_path());
+//     else
+//         Gettext.bindtextdomain(domain, Config.LOCALEDIR);
+// }

--- a/convenience.js
+++ b/convenience.js
@@ -1,6 +1,4 @@
 /*global imports, print */
-//const ExtensionUtils = imports.misc.extensionUtils;
-//const Gio = imports.gi.Gio;
 import Gio from 'gi://Gio';
 // const Gettext = imports.gettext;
 // import * as Gettext from 'resource:///org/gnome/shell/extensions/extension.js';
@@ -8,12 +6,11 @@ import Gio from 'gi://Gio';
 // import * as Config from 'resource:///org/gnome/shell/misc/config.js';
 // import * as Config from 'resource:///org/gnome/Shell/Extensions/js/misc/config.js';
 
-// import {Extension} from 'resource:///org/gnome/shell/extensions/extension.js';
-// import {Extension} from 'resource:///org/gnome/Shell/Extensions/js/extensions/extension.js';
-
+// This method can be used to import Extension or ExtensionPreferences.
+// This is done differently in the GNOME Shell process and in the preferences process.
+// Both have the lookupByUUID method, used below.
 async function importExtension() {
   if (typeof global === 'undefined') {
-    // return (await import('resource:///org/gnome/Shell/Extensions/js/extensions/extension.js')).Extension;
     return (await import('resource:///org/gnome/Shell/Extensions/js/extensions/prefs.js')).ExtensionPreferences;
   }
   return (await import('resource:///org/gnome/shell/extensions/extension.js')).Extension;
@@ -31,7 +28,6 @@ export function getSettings() {
 // copied from https://github.com/projecthamster/shell-extension/blob/f1f1d803395bc122db1b877985e1d2462c5215a9/convenience.js#L65
 export function initSettings() {
   const extension = Extension.lookupByUUID('switcher@landau.fi');
-  console.log('extension: ' + extension);
   const schema = extension.metadata['settings-schema'];
   const GioSSS = Gio.SettingsSchemaSource;
   const schemaDir = extension.dir.get_child('schemas');

--- a/extension.js
+++ b/extension.js
@@ -15,40 +15,23 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 /*global imports, print */
-// const St = imports.gi.St;
 import St from 'gi://St';
-// const Clutter = imports.gi.Clutter;
 import Clutter from 'gi://Clutter';
-// const Main = imports.ui.main;
 import * as Main from 'resource:///org/gnome/shell/ui/main.js';
-// const Shell = imports.gi.Shell;
 import Shell from 'gi://Shell';
-// const Meta = imports.gi.Meta;
 import Meta from 'gi://Meta';
 // const Gettext = imports.gettext;
-// const Tweener = imports.tweener.tweener;
-// import * as Tweener from 'resource:///org/gnome/shell/tweener/tweener.js';
 
-// const ExtensionUtils = imports.misc.extensionUtils;
-// const Me = ExtensionUtils.getCurrentExtension();
-// const Convenience = Me.imports.convenience;
 import * as Convenience from './convenience.js';
 
-// const keyActivation = Me.imports.keyActivation.KeyActivation;
 import * as KeyActivationModule from './keyActivation.js';
 
-// const switcherModule = Me.imports.modes.switcher;
 import * as switcherModule from './modes/switcher.js';
-// const launcher = Me.imports.modes.launcher.Launcher;
 import {Launcher as launcher} from './modes/launcher.js';
 
-// const modeUtils = Me.imports.modes.modeUtils.ModeUtils;
 import * as ModeUtilsModule from './modes/modeUtils.js';
-// import * as modeUtils from './modes/modeUtils.js';
 
-// const util = Me.imports.util;
 import * as util from './util.js';
-// const controlCenter = Me.imports.controlCenter;
 import * as controlCenter from './controlCenter.js';
 
 import {Extension} from 'resource:///org/gnome/shell/extensions/extension.js';
@@ -59,7 +42,6 @@ const modeUtils = ModeUtilsModule.ModeUtils;
 
 window.setTimeout = util.setTimeout;
 window.clearTimeout = util.clearTimeout;
-// const promiseModule = Me.imports.promise;
 
 let container,
   containers,
@@ -283,7 +265,6 @@ function _showUI() {
       cursor = cursor > 0 ? cursor - 1 : currentlyShowingCount - 1;
       util.updateHighlight(boxes, o.text, cursor);
     } else if (symbol === Clutter.KEY_w && control) {
-      // switcherModule.onlyCurrentWorkspaceToggled = !switcherModule.onlyCurrentWorkspaceToggled;
       switcherModule.setOnlyCurrentWorkspaceToggled(!switcherModule.onlyCurrentWorkspaceToggled)
       rerunFiltersAndUpdate(o);
     } else if (symbol === Clutter.KEY_h && control) {
@@ -436,10 +417,10 @@ function _showUI() {
   setTimeout(showSingleBox, 0);
 }
 
-function _init() {
-  Gettext.domain('switcher');
-  Gettext.bindtextdomain('switcher', Me.path + '/locale');
-}
+// function _init() {
+//   Gettext.domain('switcher');
+//   Gettext.bindtextdomain('switcher', Me.path + '/locale');
+// }
 
 function _enable() {
   Convenience.initSettings();
@@ -478,7 +459,6 @@ function cleanUI() {
   rerunFiltersAndUpdate = null;
   if (forceUpdateAppCacheTimeoutId)
     clearTimeout(forceUpdateAppCacheTimeoutId);
-  // switcherModule.onlyCurrentWorkspaceToggled = false;
   switcherModule.setOnlyCurrentWorkspaceToggled(false);
   cleanBoxes();
   containers.reverse().forEach((c) => {
@@ -497,7 +477,6 @@ function cleanUIWithFade(force_immediate = false) {
   rerunFiltersAndUpdate = null;
   if (forceUpdateAppCacheTimeoutId)
     clearTimeout(forceUpdateAppCacheTimeoutId);
-  // switcherModule.onlyCurrentWorkspaceToggled = false;
   switcherModule.setOnlyCurrentWorkspaceToggled(false);
   grabs && grabs.reverse().forEach((c) => {
     try {
@@ -518,12 +497,6 @@ function cleanUIWithFade(force_immediate = false) {
   };
 
   if (!force_immediate && Convenience.getSettings().get_boolean('fade-enable')) {
-    // Tweener.addTween(boxLayout, {
-    //   opacity: 0,
-    //   time: 0.35,
-    //   transition: 'easeOutQuad',
-    //   onComplete: cleanRest
-    // });
     boxLayout.ease(
       {
         opacity: 0,

--- a/extension.js
+++ b/extension.js
@@ -15,28 +15,51 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 /*global imports, print */
-const St = imports.gi.St;
-const Clutter = imports.gi.Clutter;
-const Main = imports.ui.main;
-const Shell = imports.gi.Shell;
-const Meta = imports.gi.Meta;
-const Gettext = imports.gettext;
-const Tweener = imports.tweener.tweener;
+// const St = imports.gi.St;
+import St from 'gi://St';
+// const Clutter = imports.gi.Clutter;
+import Clutter from 'gi://Clutter';
+// const Main = imports.ui.main;
+import * as Main from 'resource:///org/gnome/shell/ui/main.js';
+// const Shell = imports.gi.Shell;
+import Shell from 'gi://Shell';
+// const Meta = imports.gi.Meta;
+import Meta from 'gi://Meta';
+// const Gettext = imports.gettext;
+// const Tweener = imports.tweener.tweener;
+// import * as Tweener from 'resource:///org/gnome/shell/tweener/tweener.js';
 
-const ExtensionUtils = imports.misc.extensionUtils;
-const Me = ExtensionUtils.getCurrentExtension();
-const Convenience = Me.imports.convenience;
+// const ExtensionUtils = imports.misc.extensionUtils;
+// const Me = ExtensionUtils.getCurrentExtension();
+// const Convenience = Me.imports.convenience;
+import * as Convenience from './convenience.js';
 
-const keyActivation = Me.imports.keyActivation.KeyActivation;
-const switcherModule = Me.imports.modes.switcher;
+// const keyActivation = Me.imports.keyActivation.KeyActivation;
+import * as KeyActivationModule from './keyActivation.js';
+
+// const switcherModule = Me.imports.modes.switcher;
+import * as switcherModule from './modes/switcher.js';
+// const launcher = Me.imports.modes.launcher.Launcher;
+import {Launcher as launcher} from './modes/launcher.js';
+
+// const modeUtils = Me.imports.modes.modeUtils.ModeUtils;
+import * as ModeUtilsModule from './modes/modeUtils.js';
+// import * as modeUtils from './modes/modeUtils.js';
+
+// const util = Me.imports.util;
+import * as util from './util.js';
+// const controlCenter = Me.imports.controlCenter;
+import * as controlCenter from './controlCenter.js';
+
+import {Extension} from 'resource:///org/gnome/shell/extensions/extension.js';
+
+const keyActivation = KeyActivationModule.KeyActivation;
 const switcher = switcherModule.Switcher;
-const launcher = Me.imports.modes.launcher.Launcher;
-const modeUtils = Me.imports.modes.modeUtils.ModeUtils;
-const util = Me.imports.util;
-const controlCenter = Me.imports.controlCenter;
+const modeUtils = ModeUtilsModule.ModeUtils;
+
 window.setTimeout = util.setTimeout;
 window.clearTimeout = util.clearTimeout;
-const promiseModule = Me.imports.promise;
+// const promiseModule = Me.imports.promise;
 
 let container,
   containers,
@@ -175,8 +198,8 @@ function _showUI() {
   containers = allMonitors.map((monitor) => {
     let tmpContainer = new St.Bin({
       reactive: true,
-      x_align: St.Align.MIDDLE,
-      y_align: St.Align.START
+      x_align: St.TextAlign.CENTER,
+      y_align: St.TextAlign.LEFT
     });
     tmpContainer.set_width(monitor.width);
     tmpContainer.set_height(monitor.height);
@@ -260,7 +283,8 @@ function _showUI() {
       cursor = cursor > 0 ? cursor - 1 : currentlyShowingCount - 1;
       util.updateHighlight(boxes, o.text, cursor);
     } else if (symbol === Clutter.KEY_w && control) {
-      switcherModule.onlyCurrentWorkspaceToggled = !switcherModule.onlyCurrentWorkspaceToggled;
+      // switcherModule.onlyCurrentWorkspaceToggled = !switcherModule.onlyCurrentWorkspaceToggled;
+      switcherModule.setOnlyCurrentWorkspaceToggled(!switcherModule.onlyCurrentWorkspaceToggled)
       rerunFiltersAndUpdate(o);
     } else if (symbol === Clutter.KEY_h && control) {
       // Delete last character
@@ -412,12 +436,12 @@ function _showUI() {
   setTimeout(showSingleBox, 0);
 }
 
-function init() {
+function _init() {
   Gettext.domain('switcher');
   Gettext.bindtextdomain('switcher', Me.path + '/locale');
 }
 
-function enable() {
+function _enable() {
   Convenience.initSettings();
   keybindings.push(
     Main.wm.addKeybinding(
@@ -434,7 +458,7 @@ function enable() {
   setTimeout(() => modeUtils.shellApps(true), 100); // force update shell app cache
 }
 
-function disable() {
+function _disable() {
 	cleanUIWithFade(true);
   Main.wm.removeKeybinding('show-switcher');
 }
@@ -454,7 +478,8 @@ function cleanUI() {
   rerunFiltersAndUpdate = null;
   if (forceUpdateAppCacheTimeoutId)
     clearTimeout(forceUpdateAppCacheTimeoutId);
-  switcherModule.onlyCurrentWorkspaceToggled = false;
+  // switcherModule.onlyCurrentWorkspaceToggled = false;
+  switcherModule.setOnlyCurrentWorkspaceToggled(false);
   cleanBoxes();
   containers.reverse().forEach((c) => {
     Main.uiGroup.remove_actor(c);
@@ -472,7 +497,8 @@ function cleanUIWithFade(force_immediate = false) {
   rerunFiltersAndUpdate = null;
   if (forceUpdateAppCacheTimeoutId)
     clearTimeout(forceUpdateAppCacheTimeoutId);
-  switcherModule.onlyCurrentWorkspaceToggled = false;
+  // switcherModule.onlyCurrentWorkspaceToggled = false;
+  switcherModule.setOnlyCurrentWorkspaceToggled(false);
   grabs && grabs.reverse().forEach((c) => {
     try {
       Main.popModal(c);
@@ -492,12 +518,20 @@ function cleanUIWithFade(force_immediate = false) {
   };
 
   if (!force_immediate && Convenience.getSettings().get_boolean('fade-enable')) {
-    Tweener.addTween(boxLayout, {
-      opacity: 0,
-      time: 0.35,
-      transition: 'easeOutQuad',
-      onComplete: cleanRest
-    });
+    // Tweener.addTween(boxLayout, {
+    //   opacity: 0,
+    //   time: 0.35,
+    //   transition: 'easeOutQuad',
+    //   onComplete: cleanRest
+    // });
+    boxLayout.ease(
+      {
+        opacity: 0,
+        time: 0.35,
+        transition: Clutter.AnimationMode.EASE_OUT_QUAD,
+        onComplete: cleanRest
+      }
+    );
   } else {
     cleanRest();
   }
@@ -515,5 +549,17 @@ function checkNewWindows() {
     global.stage.set_key_focus(entry);
   } else {
     setTimeout(checkNewWindows, 50);
+  }
+}
+
+export default class SwitcherExtension extends Extension {
+  enable() {
+    this._settings = this.getSettings();
+    _enable();
+  }
+
+  disable() {
+    this._settings = null;
+    _disable();
   }
 }

--- a/keyActivation.js
+++ b/keyActivation.js
@@ -1,6 +1,4 @@
 import Clutter from 'gi://Clutter';
-// import * as Main from 'resource:///org/gnome/shell/ui/main.js';
-
 import * as Convenience from './convenience.js';
 
 const keyActivationNone         = 0;

--- a/keyActivation.js
+++ b/keyActivation.js
@@ -1,5 +1,5 @@
 import Clutter from 'gi://Clutter';
-import * as Main from 'resource:///org/gnome/shell/ui/main.js';
+// import * as Main from 'resource:///org/gnome/shell/ui/main.js';
 
 import * as Convenience from './convenience.js';
 

--- a/keyActivation.js
+++ b/keyActivation.js
@@ -1,9 +1,12 @@
-const Clutter = imports.gi.Clutter;
-const Main = imports.ui.main;
+// const Clutter = imports.gi.Clutter;
+import Clutter from 'gi://Clutter';
+// const Main = imports.ui.main;
+import * as Main from 'resource:///org/gnome/shell/ui/main.js';
 
-const ExtensionUtils = imports.misc.extensionUtils;
-const Me = ExtensionUtils.getCurrentExtension();
-const Convenience = Me.imports.convenience;
+// const ExtensionUtils = imports.misc.extensionUtils;
+// const Me = ExtensionUtils.getCurrentExtension();
+// const Convenience = Me.imports.convenience;
+import * as Convenience from './convenience.js';
 
 const keyActivationNone         = 0;
 const keyActivationFunctionKeys = 1;
@@ -55,7 +58,7 @@ const numberKeySymbols = {
   }
 };
 
-var KeyActivation = (function () {
+export var KeyActivation = (function () {
   var getActivateByKey = function() {
     return Convenience.getSettings().get_uint('activate-by-key');
   };

--- a/keyActivation.js
+++ b/keyActivation.js
@@ -1,11 +1,6 @@
-// const Clutter = imports.gi.Clutter;
 import Clutter from 'gi://Clutter';
-// const Main = imports.ui.main;
 import * as Main from 'resource:///org/gnome/shell/ui/main.js';
 
-// const ExtensionUtils = imports.misc.extensionUtils;
-// const Me = ExtensionUtils.getCurrentExtension();
-// const Convenience = Me.imports.convenience;
 import * as Convenience from './convenience.js';
 
 const keyActivationNone         = 0;

--- a/metadata.json
+++ b/metadata.json
@@ -4,8 +4,9 @@
   "settings-schema": "org.gnome.shell.extensions.switcher",
   "description": "Switch windows or launch applications quickly by typing\n\nUse the configured global hotkey (Super+w by default) to open a list of current windows. Type a part of the name or title of the application window you want to activate and hit enter or click on the item you wish to activate. You can use the arrow keys to navigate among the filtered selection and type several space separated search terms to filter further. If your search matches launchable apps, those are shown in the list too. Use Esc or click anywhere outside the switcher to cancel.\n\nYou can customize the look and feel and functionality in the preferences.",
   "shell-version": [
-    "44"
+    "45"
   ],
   "version": 38,
-  "url": "https://github.com/daniellandau/switcher"
+  "url": "https://github.com/daniellandau/switcher",
+  "gettext-domain": "switcher"
 }

--- a/modes/launcher.js
+++ b/modes/launcher.js
@@ -1,9 +1,3 @@
-// import St from 'gi://St';
-// import Clutter from 'gi://Clutter';
-// import * as Main from 'resource:///org/gnome/shell/ui/main.js';
-// import Shell from 'gi://Shell';
-// import Meta from 'gi://Meta';
-
 import * as Convenience from '../convenience.js';
 
 import * as modeUtils from './modeUtils.js';

--- a/modes/launcher.js
+++ b/modes/launcher.js
@@ -1,20 +1,11 @@
-// const St = imports.gi.St;
 import St from 'gi://St';
-// const Clutter = imports.gi.Clutter;
 import Clutter from 'gi://Clutter';
-// const Main = imports.ui.main;
 import * as Main from 'resource:///org/gnome/shell/ui/main.js';
-// const Shell = imports.gi.Shell;
 import Shell from 'gi://Shell';
-// const Meta = imports.gi.Meta;
 import Meta from 'gi://Meta';
 
-// const ExtensionUtils = imports.misc.extensionUtils;
-// const Me = ExtensionUtils.getCurrentExtension();
-// const Convenience = Me.imports.convenience;
 import * as Convenience from '../convenience.js';
 
-// const modeUtils = Me.imports.modes.modeUtils.ModeUtils;
 import * as modeUtils from './modeUtils.js';
 
 let stats = Convenience.getJson('launcher-stats');

--- a/modes/launcher.js
+++ b/modes/launcher.js
@@ -1,8 +1,8 @@
-import St from 'gi://St';
-import Clutter from 'gi://Clutter';
-import * as Main from 'resource:///org/gnome/shell/ui/main.js';
-import Shell from 'gi://Shell';
-import Meta from 'gi://Meta';
+// import St from 'gi://St';
+// import Clutter from 'gi://Clutter';
+// import * as Main from 'resource:///org/gnome/shell/ui/main.js';
+// import Shell from 'gi://Shell';
+// import Meta from 'gi://Meta';
 
 import * as Convenience from '../convenience.js';
 

--- a/modes/launcher.js
+++ b/modes/launcher.js
@@ -1,18 +1,25 @@
-const St = imports.gi.St;
-const Clutter = imports.gi.Clutter;
-const Main = imports.ui.main;
-const Shell = imports.gi.Shell;
-const Meta = imports.gi.Meta;
+// const St = imports.gi.St;
+import St from 'gi://St';
+// const Clutter = imports.gi.Clutter;
+import Clutter from 'gi://Clutter';
+// const Main = imports.ui.main;
+import * as Main from 'resource:///org/gnome/shell/ui/main.js';
+// const Shell = imports.gi.Shell;
+import Shell from 'gi://Shell';
+// const Meta = imports.gi.Meta;
+import Meta from 'gi://Meta';
 
-const ExtensionUtils = imports.misc.extensionUtils;
-const Me = ExtensionUtils.getCurrentExtension();
-const Convenience = Me.imports.convenience;
+// const ExtensionUtils = imports.misc.extensionUtils;
+// const Me = ExtensionUtils.getCurrentExtension();
+// const Convenience = Me.imports.convenience;
+import * as Convenience from '../convenience.js';
 
-const modeUtils = Me.imports.modes.modeUtils.ModeUtils;
+// const modeUtils = Me.imports.modes.modeUtils.ModeUtils;
+import * as modeUtils from './modeUtils.js';
 
 let stats = Convenience.getJson('launcher-stats');
 
-var Launcher = (function () {
+export var Launcher = (function () {
   // Limit the number of displayed items
   const MAX_NUM_ITEMS = 10;
 

--- a/modes/modeUtils.js
+++ b/modes/modeUtils.js
@@ -1,31 +1,17 @@
-// const St = imports.gi.St;
 import St from 'gi://St';
-// const Clutter = imports.gi.Clutter;
 import Clutter from 'gi://Clutter';
-// const Main = imports.ui.main;
 import * as Main from 'resource:///org/gnome/shell/ui/main.js';
-// const Shell = imports.gi.Shell;
 import Shell from 'gi://Shell';
-// const Meta = imports.gi.Meta;
 import Meta from 'gi://Meta';
-// const Gio = imports.gi.Gio;
 import Gio from 'gi://Gio';
-// const GLib = imports.gi.GLib;
 import GLib from 'gi://GLib';
 
-// const ExtensionUtils = imports.misc.extensionUtils;
-// const Me = ExtensionUtils.getCurrentExtension();
-// const Convenience = Me.imports.convenience;
 import * as Convenience from '../convenience.js';
 
-// const util = Me.imports.util;
 import * as util from '../util.js';
-// const controlCenter = Me.imports.controlCenter;
 import * as controlCenter from '../controlCenter.js';
-// const switcherApplication = Me.imports.switcherApplication;
 import * as switcherApplication from '../switcherApplication.js';
 
-// const keyActivation = Me.imports.keyActivation.KeyActivation;
 import * as KeyActivationModule from '../keyActivation.js';
 const keyActivation = KeyActivationModule.KeyActivation;
 

--- a/modes/modeUtils.js
+++ b/modes/modeUtils.js
@@ -1,8 +1,8 @@
 import St from 'gi://St';
 import Clutter from 'gi://Clutter';
-import * as Main from 'resource:///org/gnome/shell/ui/main.js';
+// import * as Main from 'resource:///org/gnome/shell/ui/main.js';
 import Shell from 'gi://Shell';
-import Meta from 'gi://Meta';
+// import Meta from 'gi://Meta';
 import Gio from 'gi://Gio';
 import GLib from 'gi://GLib';
 

--- a/modes/modeUtils.js
+++ b/modes/modeUtils.js
@@ -1,8 +1,6 @@
 import St from 'gi://St';
 import Clutter from 'gi://Clutter';
-// import * as Main from 'resource:///org/gnome/shell/ui/main.js';
 import Shell from 'gi://Shell';
-// import Meta from 'gi://Meta';
 import Gio from 'gi://Gio';
 import GLib from 'gi://GLib';
 

--- a/modes/modeUtils.js
+++ b/modes/modeUtils.js
@@ -1,19 +1,33 @@
-const St = imports.gi.St;
-const Clutter = imports.gi.Clutter;
-const Main = imports.ui.main;
-const Shell = imports.gi.Shell;
-const Meta = imports.gi.Meta;
-const Gio = imports.gi.Gio;
-const GLib = imports.gi.GLib;
+// const St = imports.gi.St;
+import St from 'gi://St';
+// const Clutter = imports.gi.Clutter;
+import Clutter from 'gi://Clutter';
+// const Main = imports.ui.main;
+import * as Main from 'resource:///org/gnome/shell/ui/main.js';
+// const Shell = imports.gi.Shell;
+import Shell from 'gi://Shell';
+// const Meta = imports.gi.Meta;
+import Meta from 'gi://Meta';
+// const Gio = imports.gi.Gio;
+import Gio from 'gi://Gio';
+// const GLib = imports.gi.GLib;
+import GLib from 'gi://GLib';
 
-const ExtensionUtils = imports.misc.extensionUtils;
-const Me = ExtensionUtils.getCurrentExtension();
-const Convenience = Me.imports.convenience;
-const util = Me.imports.util;
-const controlCenter = Me.imports.controlCenter;
-const switcherApplication = Me.imports.switcherApplication;
+// const ExtensionUtils = imports.misc.extensionUtils;
+// const Me = ExtensionUtils.getCurrentExtension();
+// const Convenience = Me.imports.convenience;
+import * as Convenience from '../convenience.js';
 
-const keyActivation = Me.imports.keyActivation.KeyActivation;
+// const util = Me.imports.util;
+import * as util from '../util.js';
+// const controlCenter = Me.imports.controlCenter;
+import * as controlCenter from '../controlCenter.js';
+// const switcherApplication = Me.imports.switcherApplication;
+import * as switcherApplication from '../switcherApplication.js';
+
+// const keyActivation = Me.imports.keyActivation.KeyActivation;
+import * as KeyActivationModule from '../keyActivation.js';
+const keyActivation = KeyActivationModule.KeyActivation;
 
 let gnomeControlCenterAppIDs = null;
 
@@ -51,7 +65,7 @@ function getGnomeControlCenterAppIDs() {
   return gnomeControlCenterAppIDs;
 }
 
-var ModeUtils = (function () {
+export var ModeUtils = (function () {
   // From _loadApps() in GNOME Shell's appDisplay.js
   let appInfos = () => {
     // get app ids for regular applications

--- a/modes/switcher.js
+++ b/modes/switcher.js
@@ -1,22 +1,12 @@
-// const St = imports.gi.St;
 import St from 'gi://St';
-// const Clutter = imports.gi.Clutter;
 import Clutter from 'gi://Clutter';
-// const Main = imports.ui.main;
 import * as Main from 'resource:///org/gnome/shell/ui/main.js';
-// const Shell = imports.gi.Shell;
 import Shell from 'gi://Shell';
-// const Meta = imports.gi.Meta;
 import Meta from 'gi://Meta';
 
-// const ExtensionUtils = imports.misc.extensionUtils;
-// const Me = ExtensionUtils.getCurrentExtension();
-// const Convenience = Me.imports.convenience;
 import * as Convenience from '../convenience.js';
 
-// const util = Me.imports.util;
 import * as util from '../util.js';
-// const modeUtils = Me.imports.modes.modeUtils.ModeUtils;
 import {ModeUtils as modeUtils} from './modeUtils.js';
 
 var onlyCurrentWorkspaceToggled = false;

--- a/modes/switcher.js
+++ b/modes/switcher.js
@@ -1,19 +1,31 @@
-const St = imports.gi.St;
-const Clutter = imports.gi.Clutter;
-const Main = imports.ui.main;
-const Shell = imports.gi.Shell;
-const Meta = imports.gi.Meta;
+// const St = imports.gi.St;
+import St from 'gi://St';
+// const Clutter = imports.gi.Clutter;
+import Clutter from 'gi://Clutter';
+// const Main = imports.ui.main;
+import * as Main from 'resource:///org/gnome/shell/ui/main.js';
+// const Shell = imports.gi.Shell;
+import Shell from 'gi://Shell';
+// const Meta = imports.gi.Meta;
+import Meta from 'gi://Meta';
 
-const ExtensionUtils = imports.misc.extensionUtils;
-const Me = ExtensionUtils.getCurrentExtension();
-const Convenience = Me.imports.convenience;
+// const ExtensionUtils = imports.misc.extensionUtils;
+// const Me = ExtensionUtils.getCurrentExtension();
+// const Convenience = Me.imports.convenience;
+import * as Convenience from '../convenience.js';
 
-const util = Me.imports.util;
-const modeUtils = Me.imports.modes.modeUtils.ModeUtils;
+// const util = Me.imports.util;
+import * as util from '../util.js';
+// const modeUtils = Me.imports.modes.modeUtils.ModeUtils;
+import {ModeUtils as modeUtils} from './modeUtils.js';
 
 var onlyCurrentWorkspaceToggled = false;
 
-var Switcher = (function() {
+export function setOnlyCurrentWorkspaceToggled(v) {
+  onlyCurrentWorkspaceToggled = v;
+}
+
+export var Switcher = (function() {
   // Limit the number of displayed items
   const MAX_NUM_ITEMS = 15;
 

--- a/modes/switcher.js
+++ b/modes/switcher.js
@@ -1,5 +1,5 @@
-import St from 'gi://St';
-import Clutter from 'gi://Clutter';
+// import St from 'gi://St';
+// import Clutter from 'gi://Clutter';
 import * as Main from 'resource:///org/gnome/shell/ui/main.js';
 import Shell from 'gi://Shell';
 import Meta from 'gi://Meta';

--- a/modes/switcher.js
+++ b/modes/switcher.js
@@ -1,5 +1,3 @@
-// import St from 'gi://St';
-// import Clutter from 'gi://Clutter';
 import * as Main from 'resource:///org/gnome/shell/ui/main.js';
 import Shell from 'gi://Shell';
 import Meta from 'gi://Meta';

--- a/onboardingmessages.js
+++ b/onboardingmessages.js
@@ -1,4 +1,4 @@
-function messages(_) {
+export function messages(_) {
   return [
     _("Use Super+w (or another shortcut you configured in settings) to start the switcher. Type space separated searches, use the arrow keys to navigate, and press Space to activate."),
     _("You can also click an item with the mouse/touchpad to activate."),

--- a/prefs.js
+++ b/prefs.js
@@ -1,24 +1,11 @@
 /*global imports, print */
-// const Gtk = imports.gi.Gtk;
 import Gtk from 'gi://Gtk';
-// const GObject = imports.gi.GObject;
 import GObject from 'gi://GObject';
-
-// const ExtensionUtils = imports.misc.extensionUtils;
-// import * as ExtensionUtils from 'resource:///org/gnome/shell/misc/extensionUtils.js';
-// const Me = ExtensionUtils.getCurrentExtension();
-// const Convenience = Me.imports.convenience;
 import * as Convenience from './convenience.js';
-
-// const Gettext = imports.gettext.domain('switcher');
-// const _ = Gettext.gettext;
 import {ExtensionPreferences, gettext as _} from 'resource:///org/gnome/Shell/Extensions/js/extensions/prefs.js';
-
-// const getOnboardingMessages = Me.imports.onboardingmessages.messages;
 import * as OnboardingMessages from './onboardingmessages.js';
 const getOnboardingMessages = OnboardingMessages.messages;
 
-// const { GLib, Gdk } = imports.gi;
 import GLib from 'gi://GLib';
 import Gdk from 'gi://Gdk';
 import Adw from 'gi://Adw';

--- a/prefs.js
+++ b/prefs.js
@@ -6,11 +6,11 @@ import {ExtensionPreferences, gettext as _} from 'resource:///org/gnome/Shell/Ex
 import * as OnboardingMessages from './onboardingmessages.js';
 const getOnboardingMessages = OnboardingMessages.messages;
 
-import GLib from 'gi://GLib';
+// import GLib from 'gi://GLib';
 import Gdk from 'gi://Gdk';
 import Adw from 'gi://Adw';
 
-let entry, settings;
+// let entry, settings;
 
 // function init() {
 //   Convenience.initTranslations('switcher');
@@ -18,7 +18,8 @@ let entry, settings;
 
 function buildPrefsWidget() {
   let provider = new Gtk.CssProvider();
-  provider.load_from_path(Me.dir.get_path() + '/prefs.css');
+  const extension = ExtensionPreferences.lookupByUUID('switcher@landau.fi');
+  provider.load_from_path(extension.dir.get_path() + '/prefs.css');
   Gtk.StyleContext.add_provider_for_display(
     Gdk.Display.get_default(),
     provider,
@@ -407,20 +408,17 @@ function makeTitle(markup) {
 export default class MyExtensionPreferences extends ExtensionPreferences {
   fillPreferencesWindow(window) {
       window._settings = this.getSettings();
-      const widgets = buildWidgets();
 
       const page = new Adw.PreferencesPage();
 
       const group = new Adw.PreferencesGroup({
-          title: _('Group Title'),
+          title: _('Switcher Preferences'),
       });
 
-      widgets.forEach((w) => {
-        group.add(w);
-      });
-
+      const widget = buildPrefsWidget();
+      group.add(widget);
       page.add(group);
-
       window.add(page);
+      window.set_default_size(650, 900);
   }
 }

--- a/prefs.js
+++ b/prefs.js
@@ -6,7 +6,6 @@ import {ExtensionPreferences, gettext as _} from 'resource:///org/gnome/Shell/Ex
 import * as OnboardingMessages from './onboardingmessages.js';
 const getOnboardingMessages = OnboardingMessages.messages;
 
-// import GLib from 'gi://GLib';
 import Gdk from 'gi://Gdk';
 import Adw from 'gi://Adw';
 

--- a/prefs.js
+++ b/prefs.js
@@ -1,22 +1,33 @@
 /*global imports, print */
-const Gtk = imports.gi.Gtk;
-const GObject = imports.gi.GObject;
+// const Gtk = imports.gi.Gtk;
+import Gtk from 'gi://Gtk';
+// const GObject = imports.gi.GObject;
+import GObject from 'gi://GObject';
 
-const ExtensionUtils = imports.misc.extensionUtils;
-const Me = ExtensionUtils.getCurrentExtension();
-const Convenience = Me.imports.convenience;
+// const ExtensionUtils = imports.misc.extensionUtils;
+// import * as ExtensionUtils from 'resource:///org/gnome/shell/misc/extensionUtils.js';
+// const Me = ExtensionUtils.getCurrentExtension();
+// const Convenience = Me.imports.convenience;
+import * as Convenience from './convenience.js';
 
-const Gettext = imports.gettext.domain('switcher');
-const _ = Gettext.gettext;
-const getOnboardingMessages = Me.imports.onboardingmessages.messages;
+// const Gettext = imports.gettext.domain('switcher');
+// const _ = Gettext.gettext;
+import {ExtensionPreferences, gettext as _} from 'resource:///org/gnome/Shell/Extensions/js/extensions/prefs.js';
 
-const { GLib, Gdk } = imports.gi;
+// const getOnboardingMessages = Me.imports.onboardingmessages.messages;
+import * as OnboardingMessages from './onboardingmessages.js';
+const getOnboardingMessages = OnboardingMessages.messages;
+
+// const { GLib, Gdk } = imports.gi;
+import GLib from 'gi://GLib';
+import Gdk from 'gi://Gdk';
+import Adw from 'gi://Adw';
 
 let entry, settings;
 
-function init() {
-  Convenience.initTranslations('switcher');
-}
+// function init() {
+//   Convenience.initTranslations('switcher');
+// }
 
 function buildPrefsWidget() {
   let provider = new Gtk.CssProvider();
@@ -404,4 +415,25 @@ function makeTitle(markup) {
   title.set_xalign(0);
   title.set_yalign(0.5);
   return title;
+}
+
+export default class MyExtensionPreferences extends ExtensionPreferences {
+  fillPreferencesWindow(window) {
+      window._settings = this.getSettings();
+      const widgets = buildWidgets();
+
+      const page = new Adw.PreferencesPage();
+
+      const group = new Adw.PreferencesGroup({
+          title: _('Group Title'),
+      });
+
+      widgets.forEach((w) => {
+        group.add(w);
+      });
+
+      page.add(group);
+
+      window.add(page);
+  }
 }

--- a/switcherApplication.js
+++ b/switcherApplication.js
@@ -5,7 +5,7 @@
 
 
 /* ------------------------------------------------------------------------- */
-class SwitcherApplication {
+export class SwitcherApplication {
 
   /* ....................................................................... */
   constructor(appId, shellApp=null) {
@@ -62,7 +62,7 @@ class SwitcherApplication {
 
 
 /* ------------------------------------------------------------------------- */
-var RegularApplication = class RegularApplication extends SwitcherApplication {
+export class RegularApplication extends SwitcherApplication {
 
   /* ....................................................................... */
   get_name() {
@@ -82,7 +82,7 @@ var RegularApplication = class RegularApplication extends SwitcherApplication {
 
 
 /* ------------------------------------------------------------------------- */
-var GnomeControlApplication = class GnomeControlApplication
+export class GnomeControlApplication
   extends SwitcherApplication {
 
   /* ....................................................................... */

--- a/util.js
+++ b/util.js
@@ -1,6 +1,4 @@
 const MainLoop = imports.mainloop;
-// import St from 'gi://St';
-// import Clutter from 'gi://Clutter';
 import * as Convenience from './convenience.js';
 
 const matchFuzzy = 1;

--- a/util.js
+++ b/util.js
@@ -1,24 +1,27 @@
 const MainLoop = imports.mainloop;
-const St = imports.gi.St;
-const Clutter = imports.gi.Clutter;
-const ExtensionUtils = imports.misc.extensionUtils;
-const Me = ExtensionUtils.getCurrentExtension();
-const Convenience = Me.imports.convenience;
+// const St = imports.gi.St;
+import St from 'gi://St';
+// const Clutter = imports.gi.Clutter;
+import Clutter from 'gi://Clutter';
+// const ExtensionUtils = imports.misc.extensionUtils;
+// const Me = ExtensionUtils.getCurrentExtension();
+// const Convenience = Me.imports.convenience;
+import * as Convenience from './convenience.js';
 
 const matchFuzzy = 1;
 const orderByRelevancy = 1;
 
 // from https://github.com/satya164/gjs-helpers
-var setTimeout = (f, ms) => {
+export var setTimeout = (f, ms) => {
   return MainLoop.timeout_add(ms, () => {
     f();
     return false; // Don't repeat
   });
 };
 
-var clearTimeout = (id) => MainLoop.source_remove(id);
+export var clearTimeout = (id) => MainLoop.source_remove(id);
 
-function debounce(f, ms) {
+export function debounce(f, ms) {
   let timeoutId = null;
   const debounced = function () {
     if (timeoutId) clearTimeout(timeoutId);
@@ -30,11 +33,11 @@ function debounce(f, ms) {
   return debounced;
 }
 
-function escapeChars(text) {
+export function escapeChars(text) {
   return text.replace(/[-[\]{}()*+?.,\\^$|#]/g, '\\$&');
 }
 
-function makeFilter(text) {
+export function makeFilter(text) {
   return function (app) {
     // start from zero, filters can change this up or down
     // and the scores are summed
@@ -46,7 +49,7 @@ function makeFilter(text) {
   };
 }
 
-function getCurrentWorkspace() {
+export function getCurrentWorkspace() {
   if (global.screen) {
     return global.screen.get_active_workspace_index();
   } else {
@@ -55,7 +58,7 @@ function getCurrentWorkspace() {
   }
 }
 
-function runFilter(app, fragment) {
+export function runFilter(app, fragment) {
   if (fragment == '') return true;
 
   fragment = escapeChars(fragment);
@@ -113,18 +116,18 @@ function runFilter(app, fragment) {
   return gotMatch;
 }
 
-function fixWidths(box, width, shortcutWidth) {
+export function fixWidths(box, width, shortcutWidth) {
   box.whole.set_width(width);
   if (box.shortcutBox) box.shortcutBox.set_width(shortcutWidth);
 }
 
 let latestHighLightedText = null;
 
-function reinit() {
+export function reinit() {
   latestHighLightedText = null;
 }
 
-function updateHighlight(boxes, query, cursor) {
+export function updateHighlight(boxes, query, cursor) {
   boxes.forEach((box) => {
     box.whole.remove_style_class_name('switcher-highlight');
     box.label.remove_style_pseudo_class('selected');
@@ -142,7 +145,7 @@ function updateHighlight(boxes, query, cursor) {
   }
 }
 
-function highlightText(text, query) {
+export function highlightText(text, query) {
   // Don't apply highlighting if there's no input
   if (query == '') return text.replace(/&/g, '&amp;');
 
@@ -179,7 +182,7 @@ function highlightText(text, query) {
   return result.replace(/&/g, '&amp;');
 }
 
-function detachParent(child) {
+export function detachParent(child) {
   if (child) {
     let parent = child.get_parent();
     if (parent) {
@@ -188,7 +191,7 @@ function detachParent(child) {
   }
 }
 
-function filterByText(apps, text) {
+export function filterByText(apps, text) {
   let filteredApps = apps
     .filter((app) => app.mode.filter(app.app))
     .filter(makeFilter(text));

--- a/util.js
+++ b/util.js
@@ -1,6 +1,6 @@
 const MainLoop = imports.mainloop;
-import St from 'gi://St';
-import Clutter from 'gi://Clutter';
+// import St from 'gi://St';
+// import Clutter from 'gi://Clutter';
 import * as Convenience from './convenience.js';
 
 const matchFuzzy = 1;

--- a/util.js
+++ b/util.js
@@ -1,11 +1,6 @@
 const MainLoop = imports.mainloop;
-// const St = imports.gi.St;
 import St from 'gi://St';
-// const Clutter = imports.gi.Clutter;
 import Clutter from 'gi://Clutter';
-// const ExtensionUtils = imports.misc.extensionUtils;
-// const Me = ExtensionUtils.getCurrentExtension();
-// const Convenience = Me.imports.convenience;
 import * as Convenience from './convenience.js';
 
 const matchFuzzy = 1;


### PR DESCRIPTION
Here is a pull request for initial work porting Switcher to Gnome 45.0.

I enjoy using this extension so much in my daily work that I decided to give it a try, even though I never developed a Gnome extension.

A major change in Gnome 45.0 is that the import system has changed to use ESModules.
See: https://blogs.gnome.org/shell-dev/2023/09/02/extensions-in-gnome-45/

Another change is that `extension.js` and `prefs.js` must export default classes to get picked up by Gnome.

I used the following resources to implement the changes:
- https://gjs.guide/extensions/development/creating.html
- specifically: https://gjs.guide/extensions/upgrading/gnome-shell-45.html#extension-js
- inspired some code from https://github.com/Schneegans/Burn-My-Windows, which already supports Gnome 45.0

Note: everything seems to be working fine, but:
- I still get some error messages from Gnome Shell, that I cannot explain at this time:
  - `TypeError: modeUtils.shellApps is not a function`
  - `TypeError: class constructors must be invoked with 'new'`
- The preferences window works, but the code probably needs to be refactored to follow https://gjs.guide/extensions/development/preferences.html
- I'm unsure if internationalization is still working as expected. I had to remove some code that called Gettext in order for things to work.