### PR TITLE
Make compatible with Gnome 47 and use new accent color

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -4,9 +4,9 @@
   "settings-schema": "org.gnome.shell.extensions.switcher",
   "description": "Switch windows or launch applications quickly by typing\n\nUse the configured global hotkey (Super+w by default) to open a list of current windows. Type a part of the name or title of the application window you want to activate and hit enter or click on the item you wish to activate. You can use the arrow keys to navigate among the filtered selection and type several space separated search terms to filter further. If your search matches launchable apps, those are shown in the list too. Use Esc or click anywhere outside the switcher to cancel.\n\nYou can customize the look and feel and functionality in the preferences.",
   "shell-version": [
-    "46"
+    "47"
   ],
-  "version": 41,
+  "version": 42,
   "url": "https://github.com/daniellandau/switcher",
   "gettext-domain": "switcher"
 }

--- a/prefs.js
+++ b/prefs.js
@@ -360,7 +360,7 @@ function buildOnboarding(settings) {
 
   const showMessages = new Gtk.Button({ label: _('Read all tips') });
   showMessages.set_margin_top(10);
-  const popover = new Gtk.Popover(showMessages);
+  const popover = new Gtk.Popover();
   popover.set_parent(showMessages);
   const vbox = new Gtk.Box();
   vbox.set_orientation(Gtk.Orientation.VERTICAL);
@@ -399,7 +399,7 @@ function makeTitle(markup) {
 }
 
 export default class MyExtensionPreferences extends ExtensionPreferences {
-  fillPreferencesWindow(window) {
+  async fillPreferencesWindow(window) {
       window._settings = this.getSettings();
 
       const page = new Adw.PreferencesPage();

--- a/stylesheet.css
+++ b/stylesheet.css
@@ -24,13 +24,12 @@
 }
 
 .switcher-highlight {
-  color: #ffffff;
-  background-color: #215d9c;
+  color: -st-accent-fg-color;
+  background-color: -st-accent-color;
 }
 
 .switcher-highlight:hover {
   color: #ffffff;
-  background-color: #447dbc;
 }
 
 .switcher-entry {


### PR DESCRIPTION
Hi! This is for Gnome 47 compatibility with a suggestion to use the new accent color that is available.

The changes are really simple. It works fine on my PC.

It's really similar to #171, except it fixes the preferences window and adds the accent color. I couldn't find how to amend #171, so I made a new pull request.

Reference:
https://gjs.guide/extensions/upgrading/gnome-shell-47.html