### PR TITLE
Add GNOME 46 to supported shell versions

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -35,10 +35,13 @@ import * as util from './util.js';
 import * as controlCenter from './controlCenter.js';
 
 import {Extension} from 'resource:///org/gnome/shell/extensions/extension.js';
+import * as Config from 'resource:///org/gnome/shell/misc/config.js';
 
 const keyActivation = KeyActivationModule.KeyActivation;
 const switcher = switcherModule.Switcher;
 const modeUtils = ModeUtilsModule.ModeUtils;
+
+const gnomeVersion = parseInt(Config.PACKAGE_VERSION.split('.')[0]);
 
 window.setTimeout = util.setTimeout;
 window.clearTimeout = util.clearTimeout;
@@ -156,6 +159,9 @@ function _showUI() {
 
   const fontSize = Convenience.getSettings().get_uint('font-size');
   boxLayout = new St.BoxLayout({ style_class: 'switcher-box-layout' });
+  if (gnomeVersion === 46) {
+    boxLayout.add_style_class_name('switcher-legacy');
+  }
   boxLayout.set_style('font-size: ' + fontSize + 'px');
   boxLayout.set_vertical(true);
 

--- a/metadata.json
+++ b/metadata.json
@@ -4,6 +4,7 @@
   "settings-schema": "org.gnome.shell.extensions.switcher",
   "description": "Switch windows or launch applications quickly by typing\n\nUse the configured global hotkey (Super+w by default) to open a list of current windows. Type a part of the name or title of the application window you want to activate and hit enter or click on the item you wish to activate. You can use the arrow keys to navigate among the filtered selection and type several space separated search terms to filter further. If your search matches launchable apps, those are shown in the list too. Use Esc or click anywhere outside the switcher to cancel.\n\nYou can customize the look and feel and functionality in the preferences.",
   "shell-version": [
+    "46",
     "47",
     "48",
     "49"

--- a/stylesheet.css
+++ b/stylesheet.css
@@ -28,8 +28,17 @@
   background-color: -st-accent-color;
 }
 
+.switcher-legacy .switcher-highlight {
+  color: #ffffff;
+  background-color: #215d9c;
+}
+
 .switcher-highlight:hover {
   color: #ffffff;
+}
+
+.switcher-legacy .switcher-highlight:hover {
+  background-color: #447dbc;
 }
 
 .switcher-entry {


### PR DESCRIPTION
## Summary
- Add GNOME Shell 46 to the supported versions list in metadata.json.

## Rationale
- The extension runs on GNOME 46 with the existing ES module–based code.
- Having 46 in metadata.json allows installation from extensions.gnome.org on that release.

## Testing
- GNOME Shell 46.x: hotkey launches switcher, window/app search works, prefs dialog opens.

(fixes #185)