### PR TITLE
Fix: dash in search now no longer filters out window titles with dashes in them

### DIFF
--- a/util.js
+++ b/util.js
@@ -35,9 +35,10 @@ export function makeFilter(text) {
     // start from zero, filters can change this up or down
     // and the scores are summed
     app.app.score = 0;
-    app.app.cachedDescription = escapeChars(
-      app.mode.description(app.app).toLowerCase()
-    );
+    // Keep the cached description literal so punctuation (like dashes) can be matched directly
+    app.app.cachedDescription = app.mode
+      .description(app.app)
+      .toLowerCase();
     return text.split(' ').every((fragment) => runFilter(app.app, fragment));
   };
 }

--- a/util.js
+++ b/util.js
@@ -35,7 +35,6 @@ export function makeFilter(text) {
     // start from zero, filters can change this up or down
     // and the scores are summed
     app.app.score = 0;
-    // Keep the cached description literal so punctuation (like dashes) can be matched directly
     app.app.cachedDescription = app.mode
       .description(app.app)
       .toLowerCase();


### PR DESCRIPTION
- stop escaping cached descriptions before filtering so literal punctuation (like dashes) can be matched
- keep fragment escaping so regex construction remains safe while allowing hyphenated names to match
- resolves #181 where queries containing '-' failed to find matching apps/descriptions

<img width="945" height="768" alt="image" src="https://github.com/user-attachments/assets/6287f23f-e456-47e3-a90f-f8ea46c3f9c4" />
