### PR TITLE
Added the Power Actions : Shutdown , Log out , Restart , Sleep , Lock…

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -27,15 +27,15 @@ import * as Convenience from './convenience.js';
 import * as KeyActivationModule from './keyActivation.js';
 
 import * as switcherModule from './modes/switcher.js';
-import {Launcher as launcher, initStats} from './modes/launcher.js';
+import { Launcher as launcher, initStats } from './modes/launcher.js';
 
 import * as ModeUtilsModule from './modes/modeUtils.js';
 
 import * as util from './util.js';
 import * as controlCenter from './controlCenter.js';
 
-import {Extension} from 'resource:///org/gnome/shell/extensions/extension.js';
-
+import { Extension } from 'resource:///org/gnome/shell/extensions/extension.js';
+import { Power as power } from './modes/power.js';
 const keyActivation = KeyActivationModule.KeyActivation;
 const switcher = switcherModule.Switcher;
 const modeUtils = ModeUtilsModule.ModeUtils;
@@ -62,7 +62,7 @@ const enablePerfTracing = false;
 let previous = null,
   previousMessage = null;
 
-let apps = [], windows = [], allLauncherApps = [], launcherApps = [];
+let apps = [], windows = [], allLauncherApps = [], launcherApps = [], powerApps = [];
 let windowApps = new Set();
 let rerunFiltersAndUpdate = null;
 
@@ -95,7 +95,7 @@ function forceUpdateAppCacheCallback() {
     launcherApps = allLauncherApps.filter(
       (app) => !windowApps.has(app.app.get_id())
     );
-    apps = [].concat.apply([], [windows, launcherApps]);
+    apps = [].concat.apply([], [windows, launcherApps, powerApps]);
     if (rerunFiltersAndUpdate) rerunFiltersAndUpdate(entry);
   }
 }
@@ -106,7 +106,7 @@ function _showUI() {
   timeit('init');
   forceUpdateAppCacheTimeoutId = setTimeout(forceUpdateAppCacheCallback, APP_CACHE_TIMEOUT);
 
-  const modes = [switcher, launcher];
+  const modes = [switcher, launcher, power];
 
   previousEntryContent = '';
   initialHotkeyConsumed = false;
@@ -206,6 +206,8 @@ function _showUI() {
   let filteredApps = windows;
 
   rerunFiltersAndUpdate = (o) => {
+    apps = [].concat(windows, launcherApps, powerApps);
+
     filteredApps = util.filterByText(apps, o.text);
     if (
       Convenience.getSettings().get_boolean('activate-immediately') &&
@@ -227,6 +229,7 @@ function _showUI() {
 
   allLauncherApps = [];
   launcherApps = [];
+  powerApps = power.apps();
 
   const debouncedActivateUnique = util.debounce(() => {
     if (filteredApps.length === 1) {
@@ -378,13 +381,13 @@ function _showUI() {
   });
 
   grabs = containers.map((c) => {
-    let grab =  Main.pushModal(c, { actionMode: Shell.ActionMode.SYSTEM_MODAL });
+    let grab = Main.pushModal(c, { actionMode: Shell.ActionMode.SYSTEM_MODAL });
 
     c.connect('button-press-event', cleanUIWithFade);
     c.show();
-	  return grab;
+    return grab;
   });
-	grabs.push(Main.pushModal(boxLayout, { actionMode: Shell.ActionMode.SYSTEM_MODAL}))
+  grabs.push(Main.pushModal(boxLayout, { actionMode: Shell.ActionMode.SYSTEM_MODAL }))
   global.stage.set_key_focus(entry);
 
   let i = 0;
@@ -399,7 +402,7 @@ function _showUI() {
       util.fixWidths(box, width, shortcutWidth);
       i += 1;
       setTimeout(showSingleBox, 0);
-    } else if (!allWindowsShown){
+    } else if (!allWindowsShown) {
       timeit('all windows now shown')
       allWindowsShown = true;
       setTimeout(function () {
@@ -408,7 +411,7 @@ function _showUI() {
         launcherApps = allLauncherApps.filter(
           (app) => !windowApps.has(app.app.get_id())
         );
-        apps = [].concat.apply([], [windows, launcherApps]);
+        apps = [].concat.apply([], [windows, launcherApps, powerApps]);
         rerunFiltersAndUpdate(entry);
       }, 10);
     }
@@ -433,7 +436,7 @@ function _enable() {
 }
 
 function _disable() {
-	cleanUIWithFade(true);
+  cleanUIWithFade(true);
   Main.wm.removeKeybinding('show-switcher');
 }
 

--- a/modes/power.js
+++ b/modes/power.js
@@ -250,7 +250,7 @@ export var Power = (function () {
       appObj,
       shim,                  // "app"    arg — used internally for identity
       shim,                  // "appRef" arg — used for icon + get_id()
-      description,           // display Label(keyword)
+      description(action),   // display Label(keyword)
       index,
       onActivate,
       oldBox,

--- a/modes/power.js
+++ b/modes/power.js
@@ -48,7 +48,7 @@ const POWER_ACTIONS = [
     id: 'power-shutdown',
     label: 'Shutdown',
     icon: 'system-shutdown-symbolic',
-    keywords: 'shutdown power off halt',
+    keywords: 'power off',
     confirm: true,
     run() {
       callDBus(
@@ -65,7 +65,7 @@ const POWER_ACTIONS = [
     id: 'power-reboot',
     label: 'Reboot',
     icon: 'system-reboot-symbolic',
-    keywords: 'reboot restart',
+    keywords: 'restart',
     confirm: true,
     run() {
       callDBus(
@@ -82,7 +82,7 @@ const POWER_ACTIONS = [
     id: 'power-sleep',
     label: 'Sleep',
     icon: 'weather-clear-night-symbolic',
-    keywords: 'sleep suspend',
+    keywords: 'suspend',
     run() {
       callDBus(
         'system',
@@ -98,7 +98,6 @@ const POWER_ACTIONS = [
     id: 'power-hibernate',
     label: 'Hibernate',
     icon: 'drive-harddisk-symbolic',
-    keywords: 'hibernate',
     run() {
       callDBus(
         'system',
@@ -114,7 +113,7 @@ const POWER_ACTIONS = [
     id: 'power-logout',
     label: 'Log Out',
     icon: 'system-log-out-symbolic',
-    keywords: 'logout log out sign out session end',
+    keywords: 'logout signout session end',
     confirm: true,
     run() {
       callDBus(
@@ -125,16 +124,6 @@ const POWER_ACTIONS = [
         'Logout',
         new GLib.Variant('(u)', [1]),
       );
-    },
-  },
-  {
-    id: 'power-lock',
-    label: 'Lock Screen',
-    icon: 'changes-prevent-symbolic',
-    keywords: 'lock screen',
-    run() {
-      // Use GNOME Shell's built-in screen shield directly — simplest approach
-      Main.screenShield.lock(true);
     },
   },
 ];
@@ -234,7 +223,7 @@ export var Power = (function () {
    * The fuzzy filter in util.js matches against this string, so we embed
    * both the display label and the keywords.
    */
-  let description = action => `${action.label}  ${action.keywords}`;
+  let description = action => action.keywords ? `${action.label} (${action.keywords})` : action.label;
 
   /** Called by extension.js when an entry is activated. */
   let activate = action => {
@@ -252,7 +241,7 @@ export var Power = (function () {
       appObj,
       shim,                  // "app"    arg — used internally for identity
       shim,                  // "appRef" arg — used for icon + get_id()
-      action.label,         // display text — only the human-readable label
+      action.keywords ? `${action.label} (${action.keywords})` : action.label, // display Label(keyword)
       index,
       onActivate,
       oldBox,

--- a/modes/power.js
+++ b/modes/power.js
@@ -130,7 +130,6 @@ const POWER_ACTIONS = [
     id: 'power-lock',                                                           
     label: 'Lock Screen',                                                       
     icon: 'changes-prevent-symbolic',                                           
-    keywords: 'lock screen',                                                    
     run() {                                                                     
       // Use GNOME Shell's built-in screen shield directly — simplest approach  
       Main.screenShield.lock(true);                                             

--- a/modes/power.js
+++ b/modes/power.js
@@ -126,6 +126,16 @@ const POWER_ACTIONS = [
       );
     },
   },
+  {                                                                             
+    id: 'power-lock',                                                           
+    label: 'Lock Screen',                                                       
+    icon: 'changes-prevent-symbolic',                                           
+    keywords: 'lock screen',                                                    
+    run() {                                                                     
+      // Use GNOME Shell's built-in screen shield directly — simplest approach  
+      Main.screenShield.lock(true);                                             
+    },                                                                          
+  },
 ];
 
 /* -------------------------------------------------------------------------- */
@@ -241,7 +251,7 @@ export var Power = (function () {
       appObj,
       shim,                  // "app"    arg — used internally for identity
       shim,                  // "appRef" arg — used for icon + get_id()
-      action.keywords ? `${action.label} (${action.keywords})` : action.label, // display Label(keyword)
+      description,           // display Label(keyword)
       index,
       onActivate,
       oldBox,

--- a/modes/power.js
+++ b/modes/power.js
@@ -1,0 +1,272 @@
+// Power/session actions mode for the Switcher extension
+// Provides: Shutdown, Reboot, Sleep, Hibernate, Log Out, Lock Screen
+
+import St from 'gi://St';
+import Gio from 'gi://Gio';
+import GLib from 'gi://GLib';
+import Clutter from 'gi://Clutter';
+import * as Main from 'resource:///org/gnome/shell/ui/main.js';
+import * as ModalDialog from 'resource:///org/gnome/shell/ui/modalDialog.js';
+
+import { ModeUtils as modeUtils } from './modeUtils.js';
+
+/* -------------------------------------------------------------------------- */
+/* D-Bus helpers                                                               */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * Call a D-Bus method synchronously, swallowing errors gracefully.
+ *
+ * @param {'session'|'system'} bus      Which bus to use
+ * @param {string}             name     Well-known bus name
+ * @param {string}             path     Object path
+ * @param {string}             iface    Interface name
+ * @param {string}             method   Method name
+ * @param {GLib.Variant|null}  params   Encoded parameters, or null
+ */
+function callDBus(bus, name, path, iface, method, params) {
+  try {
+    Gio.DBus[bus].call_sync(
+      name, path, iface, method,
+      params,          // GLib.Variant or null
+      null,            // expected reply type (null = don't check)
+      Gio.DBusCallFlags.NONE,
+      -1,              // default timeout
+      null,            // cancellable
+    );
+  } catch (e) {
+    log(`Switcher – power action "${method}" failed: ${e}`);
+  }
+}
+
+/* -------------------------------------------------------------------------- */
+/* Action definitions                                                          */
+/* -------------------------------------------------------------------------- */
+
+const POWER_ACTIONS = [
+  {
+    id: 'power-shutdown',
+    label: 'Shutdown',
+    icon: 'system-shutdown-symbolic',
+    keywords: 'shutdown power off halt',
+    confirm: true,
+    run() {
+      callDBus(
+        'system',
+        'org.freedesktop.login1',
+        '/org/freedesktop/login1',
+        'org.freedesktop.login1.Manager',
+        'PowerOff',
+        new GLib.Variant('(b)', [true]),
+      );
+    },
+  },
+  {
+    id: 'power-reboot',
+    label: 'Reboot',
+    icon: 'system-reboot-symbolic',
+    keywords: 'reboot restart',
+    confirm: true,
+    run() {
+      callDBus(
+        'system',
+        'org.freedesktop.login1',
+        '/org/freedesktop/login1',
+        'org.freedesktop.login1.Manager',
+        'Reboot',
+        new GLib.Variant('(b)', [true]),
+      );
+    },
+  },
+  {
+    id: 'power-sleep',
+    label: 'Sleep',
+    icon: 'weather-clear-night-symbolic',
+    keywords: 'sleep suspend',
+    run() {
+      callDBus(
+        'system',
+        'org.freedesktop.login1',
+        '/org/freedesktop/login1',
+        'org.freedesktop.login1.Manager',
+        'Suspend',
+        new GLib.Variant('(b)', [true]),
+      );
+    },
+  },
+  {
+    id: 'power-hibernate',
+    label: 'Hibernate',
+    icon: 'drive-harddisk-symbolic',
+    keywords: 'hibernate',
+    run() {
+      callDBus(
+        'system',
+        'org.freedesktop.login1',
+        '/org/freedesktop/login1',
+        'org.freedesktop.login1.Manager',
+        'Hibernate',
+        new GLib.Variant('(b)', [true]),
+      );
+    },
+  },
+  {
+    id: 'power-logout',
+    label: 'Log Out',
+    icon: 'system-log-out-symbolic',
+    keywords: 'logout log out sign out session end',
+    confirm: true,
+    run() {
+      callDBus(
+        'session',
+        'org.gnome.SessionManager',
+        '/org/gnome/SessionManager',
+        'org.gnome.SessionManager',
+        'Logout',
+        new GLib.Variant('(u)', [1]),
+      );
+    },
+  },
+  {
+    id: 'power-lock',
+    label: 'Lock Screen',
+    icon: 'changes-prevent-symbolic',
+    keywords: 'lock screen',
+    run() {
+      // Use GNOME Shell's built-in screen shield directly — simplest approach
+      Main.screenShield.lock(true);
+    },
+  },
+];
+
+/* -------------------------------------------------------------------------- */
+/* Confirmation dialog                                                         */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * Shows a GNOME ModalDialog asking the user to confirm a destructive power
+ * action.  Calls onConfirm() if the user clicks the action button.
+ *
+ * @param {object}   action     A POWER_ACTIONS entry (must have .label)
+ * @param {Function} onConfirm  Called when the user confirms
+ */
+function showConfirmDialog(action, onConfirm) {
+  // Defer to next event-loop tick so the switcher UI's modal grabs are
+  // released (via cleanUIWithFade) before we try to push our own modal.
+  GLib.timeout_add(GLib.PRIORITY_DEFAULT, 0, () => {
+    const dialog = new ModalDialog.ModalDialog({ destroyOnClose: true });
+
+    // Message label
+    const label = new St.Label({
+      text: `Are you sure you want to ${action.label.toLowerCase()}?`,
+      style: 'font-size: 1em; padding: 8px 0;',
+    });
+    dialog.contentLayout.add_child(label);
+
+    // Buttons: Cancel + confirm action
+    dialog.setButtons([
+      {
+        label: 'Cancel',
+        action: () => dialog.close(),
+        key: Clutter.KEY_Escape,
+      },
+      {
+        label: action.label,
+        action: () => {
+          dialog.close();
+          onConfirm();
+        },
+        default: true,
+      },
+    ]);
+
+    dialog.open();
+    return GLib.SOURCE_REMOVE;
+  });
+}
+
+/* -------------------------------------------------------------------------- */
+/* Shim: make a power action look like a GNOME app to modeUtils               */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * modeUtils.makeBox() expects an object with get_id() and
+ * create_icon_texture(). Power actions are not real Shell apps, so we build
+ * a minimal compatible shim.
+ */
+function makeAppShim(action) {
+  return {
+    get_id: () => action.id,
+    get_name: () => action.label,
+    get_app_info: () => null,  // returning null is fine; modeUtils handles it
+    create_icon_texture: (size) =>
+      new St.Icon({
+        icon_name: action.icon,
+        icon_size: size,
+        style_class: 'popup-menu-icon',
+      }),
+  };
+}
+
+/* -------------------------------------------------------------------------- */
+/* Power mode object                                                           */
+/* -------------------------------------------------------------------------- */
+
+export var Power = (function () {
+
+  let name = () => 'Power';
+
+  /**
+   * Returns the list of power action entries in the shape the UI expects:
+   *   { app, mode, activate }
+   */
+  let apps = () =>
+    POWER_ACTIONS.map(action => ({
+      app: action,
+      mode: Power,
+      activate: () => activate(action),
+    }));
+
+  /** All power actions are always eligible to be shown. */
+  let filter = () => true;
+
+  /**
+   * The fuzzy filter in util.js matches against this string, so we embed
+   * both the display label and the keywords.
+   */
+  let description = action => `${action.label}  ${action.keywords}`;
+
+  /** Called by extension.js when an entry is activated. */
+  let activate = action => {
+    if (action.confirm)
+      showConfirmDialog(action, () => action.run());
+    else
+      action.run();
+  };
+
+  /** Builds the visual row for a power action. */
+  let makeBox = (appObj, index, onActivate, oldBox) => {
+    const action = appObj.app;
+    const shim = makeAppShim(action);
+    return modeUtils.makeBox(
+      appObj,
+      shim,                  // "app"    arg — used internally for identity
+      shim,                  // "appRef" arg — used for icon + get_id()
+      action.label,         // display text — only the human-readable label
+      index,
+      onActivate,
+      oldBox,
+    );
+  };
+
+  return {
+    MAX_NUM_ITEMS: POWER_ACTIONS.length,
+    name,
+    apps,
+    filter,
+    activate,
+    description,
+    makeBox,
+    cleanIDs: modeUtils.cleanIDs,
+  };
+})();


### PR DESCRIPTION
Fixes #194 
Adds support for common system power actions to Switcher, closing #194:
- Shutdown
- Restart
- Sleep
- Hibernate (where supported)
- Lock screen
- Log out