### PR TITLE
Restore previous switcher CSS

### DIFF
--- a/stylesheet.css
+++ b/stylesheet.css
@@ -24,12 +24,13 @@
 }
 
 .switcher-highlight {
-  color: -st-accent-fg-color;
-  background-color: -st-accent-color;
+  color: #ffffff;
+  background-color: #215d9c;
 }
 
 .switcher-highlight:hover {
   color: #ffffff;
+  background-color: #447dbc;
 }
 
 .switcher-entry {


### PR DESCRIPTION
Revert accidental style changes from previous commit

The previous commit unintentionally included some styling changes. 
This reverts the switcher's appearance back to the original.